### PR TITLE
More readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,10 @@ let query = try! language.query(contentsOf: url)
 // step 2: configure the client
 
 // produce a transformer function that can map UTF16 code point indexes to Point (Line, Offset) structs
-let transformer = { Int -> Point? in ... }
-
+let transformer: Point.LocationTransformer = { codePointIndex in 
+	return nil // Should return "Point" in text layout
+}
+		
 let client = TreeSitterClient(language: language, transformer: transformer)
 
 // this function will be called with a minimal set of text ranges
@@ -220,7 +222,9 @@ let client = TreeSitterClient(language: language, transformer: transformer)
 // always correspond to the *current* state of the text content,
 // even if TreeSitterClient is currently processing edits in the
 // background.
-client.invalidationHandler = { set in ... }
+client.invalidationHandler = { textTarget in
+	// TextTarget is a set, range, or .all
+}
 
 // step 3: inform it about content changes
 // these APIs match up fairly closely with NSTextStorageDelegate,
@@ -240,10 +244,13 @@ client.didChangeContent(to: string, in: range, delta: delta, limit: limit)
 // so makes the process both faster and simpler, but could result in lower-quality
 // and even incorrect highlighting.
 
-let provider: TreeSitterClient.TextProvider = { (range, _) -> String? in ... }
+let provider: TreeSitterClient.TextProvider = { (range, _) -> String? in
+	return nil
+}
 
+let range = NSMakeRange(0, 10) // for example
 client.executeHighlightsQuery(query, in: range, textProvider: provider) { result in
-    // Token values will tell you the highlights.scm name and range in your text
+	// Token values will tell you the highlights.scm name and range in your text
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ let query = try! language.query(contentsOf: url)
 
 // produce a transformer function that can map UTF16 code point indexes to Point (Line, Offset) structs
 let transformer: Point.LocationTransformer = { codePointIndex in 
-	return nil // Should return "Point" in text layout
+   return nil // Should return "Point" in text layout
 }
-		
+      
 let client = TreeSitterClient(language: language, transformer: transformer)
 
 // this function will be called with a minimal set of text ranges
@@ -223,7 +223,7 @@ let client = TreeSitterClient(language: language, transformer: transformer)
 // even if TreeSitterClient is currently processing edits in the
 // background.
 client.invalidationHandler = { textTarget in
-	// TextTarget is a set, range, or .all
+   // TextTarget is a set, range, or .all
 }
 
 // step 3: inform it about content changes
@@ -245,12 +245,12 @@ client.didChangeContent(to: string, in: range, delta: delta, limit: limit)
 // and even incorrect highlighting.
 
 let provider: TreeSitterClient.TextProvider = { (range, _) -> String? in
-	return nil
+   return nil
 }
 
 let range = NSMakeRange(0, 10) // for example
 client.executeHighlightsQuery(query, in: range, textProvider: provider) { result in
-	// Token values will tell you the highlights.scm name and range in your text
+   // Token values will tell you the highlights.scm name and range in your text
 }
 ```
 

--- a/Sources/Neon/TreeSitterClient.swift
+++ b/Sources/Neon/TreeSitterClient.swift
@@ -89,7 +89,7 @@ extension TreeSitterClient {
     /// Prepare for a content change.
     ///
     /// This method must be called before any content changes have been applied that
-    /// would affect how the `transformer`paramter will behave.
+    /// would affect how the `transformer`parameter will behave.
     ///
     /// - Parameter range: the range of content that will be affected by an edit
     public func willChangeContent(in range: NSRange) {

--- a/Sources/Neon/TreeSitterClient.swift
+++ b/Sources/Neon/TreeSitterClient.swift
@@ -141,7 +141,7 @@ extension TreeSitterClient {
     /// Process a string representing text content.
     ///
     /// This method is similar to `didChangeContent(in:delta:limit:readHandler:completionHandler:)`,
-    /// but it makse use of the immutability of String to meet the content
+    /// but it makesd use of the immutability of String to meet the content
     /// requirements. This makes it much easier to use. However,
     /// this approach may not be able to acheive the same level of performance.
     ///

--- a/Sources/Neon/TreeSitterClient.swift
+++ b/Sources/Neon/TreeSitterClient.swift
@@ -141,7 +141,7 @@ extension TreeSitterClient {
     /// Process a string representing text content.
     ///
     /// This method is similar to `didChangeContent(in:delta:limit:readHandler:completionHandler:)`,
-    /// but it makesd use of the immutability of String to meet the content
+    /// but it makes use of the immutability of String to meet the content
     /// requirements. This makes it much easier to use. However,
     /// this approach may not be able to acheive the same level of performance.
     ///


### PR DESCRIPTION
Some typo fixes and changes that make the advanced examples compile as shown. I think this will aid in adoption as people are trying to figure out how to use the advanced integration.