### PR TITLE
Show README image in @2x quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ func attributeProvider(_ token: Token) -> [NSAttributedString.Key: Any]? {
 
 Now our example achieves its goal of "painting black" any runs of non-whitespace characters, along with single whitespace characters between them:
 
-![Screenshot of 'Paint it Black' text window showing text with a black background and red text.](PaintItBlack.png)
+<img src="PaintItBlack.png?raw=true" width="582" alt="Screenshot of 'Paint it Black' text window showing text with a black background and red text." />
 
 Using this basic structure you can annotate the text with tokens while separately determining the appropriate styling for those tokens.
 


### PR DESCRIPTION
@danielpunkass Pointed out why the width was set, and I just didn't notice the effect :)  Fixed in this form