### PR TITLE
Map the visible rect to the text container

### DIFF
--- a/Sources/Neon/TextContainerSystemInterface.swift
+++ b/Sources/Neon/TextContainerSystemInterface.swift
@@ -15,7 +15,7 @@ extension NSTextView {
         }
 
         let origin = textContainerOrigin
-        let offsetRect = rect.offsetBy(dx: origin.x, dy: origin.y)
+        let offsetRect = rect.offsetBy(dx: -origin.x, dy: -origin.y)
 
         let glyphRange = layoutManager.glyphRange(forBoundingRect: offsetRect, in: container)
 


### PR DESCRIPTION
 by subtracting the text container's origin from the visible rect's origin.

I think this is the right way to map and maybe you hadn't noticed before if the text container offset was very small or zero?