### PR TITLE
Optional transformer function in TreeSitterClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ This class is an asynchronous interface to tree-sitter. It provides an UTF-16 co
 
 - Monitors text changes
 - Can be used to build a `TokenProvider`
-- Requires a function that can translate UTF-16 code points to a tree-sitter `Point` (line + offset)
 
 `TreeSitterClient` provides APIs that can be both synchronous, asynchronous, or both depending on the state of the system. This kind of interface can be important when optimizing for flicker-free, low-latency highlighting live typing interactions like indenting.
 
@@ -208,12 +207,7 @@ let query = try! language.query(contentsOf: url)
 
 // step 2: configure the client
 
-// produce a transformer function that can map UTF16 code point indexes to Point (Line, Offset) structs
-let transformer: Point.LocationTransformer = { codePointIndex in 
-   return nil // Should return "Point" in text layout
-}
-
-let client = TreeSitterClient(language: language, transformer: transformer)
+let client = TreeSitterClient(language: language)
 
 // this function will be called with a minimal set of text ranges
 // that have become invalidated due to edits. These ranges

--- a/Sources/TreeSitterClient/TreeSitter+Extensions.swift
+++ b/Sources/TreeSitterClient/TreeSitter+Extensions.swift
@@ -15,25 +15,19 @@ extension InputEdit {
             return nil
         }
 
-        let startPoint, newEndPoint: Point?
-        if let transformer = transformer {
-            startPoint = transformer(startLocation)
-            newEndPoint = transformer(newEndLocation)
-            if startPoint == nil || newEndPoint == nil {
-                return nil
-            }
-        } else {
-            startPoint = .zero
-            newEndPoint = .zero
+        let startPoint = transformer?(startLocation)
+        let newEndPoint = transformer?(newEndLocation)
+
+        if transformer != nil {
+            assert(startPoint != nil)
+            assert(newEndPoint != nil)
         }
 
-        assert(startPoint != nil, "startPoint should not be nil")
-        assert(newEndPoint != nil, "newEndPoint should not be nil")
         self.init(startByte: UInt32(range.location * 2),
                   oldEndByte: UInt32(range.max * 2),
                   newEndByte: UInt32(newEndLocation * 2),
-                  startPoint: startPoint!,
+                  startPoint: startPoint ?? .zero,
                   oldEndPoint: oldEndPoint,
-                  newEndPoint: newEndPoint!)
+                  newEndPoint: newEndPoint ?? .zero)
     }
 }

--- a/Sources/TreeSitterClient/TreeSitter+Extensions.swift
+++ b/Sources/TreeSitterClient/TreeSitter+Extensions.swift
@@ -6,7 +6,7 @@ extension Point {
 }
 
 extension InputEdit {
-    init?(range: NSRange, delta: Int, oldEndPoint: Point = .zero, transformer: Point.LocationTransformer? = nil) {
+    init?(range: NSRange, delta: Int, oldEndPoint: Point, transformer: Point.LocationTransformer? = nil) {
         let startLocation = range.location
         let newEndLocation = range.max + delta
 
@@ -15,14 +15,25 @@ extension InputEdit {
             return nil
         }
 
-        let startPoint = transformer?(startLocation) ?? .zero
-        let newEndPoint = transformer?(newEndLocation) ?? .zero
+        let startPoint, newEndPoint: Point?
+        if let transformer = transformer {
+            startPoint = transformer(startLocation)
+            newEndPoint = transformer(newEndLocation)
+            if startPoint == nil || newEndPoint == nil {
+                return nil
+            }
+        } else {
+            startPoint = .zero
+            newEndPoint = .zero
+        }
 
+        assert(startPoint != nil, "startPoint should not be nil")
+        assert(newEndPoint != nil, "newEndPoint should not be nil")
         self.init(startByte: UInt32(range.location * 2),
                   oldEndByte: UInt32(range.max * 2),
                   newEndByte: UInt32(newEndLocation * 2),
-                  startPoint: startPoint,
+                  startPoint: startPoint!,
                   oldEndPoint: oldEndPoint,
-                  newEndPoint: newEndPoint)
+                  newEndPoint: newEndPoint!)
     }
 }

--- a/Sources/TreeSitterClient/TreeSitter+Extensions.swift
+++ b/Sources/TreeSitterClient/TreeSitter+Extensions.swift
@@ -6,7 +6,7 @@ extension Point {
 }
 
 extension InputEdit {
-    init?(range: NSRange, delta: Int, oldEndPoint: Point, transformer: Point.LocationTransformer) {
+    init?(range: NSRange, delta: Int, oldEndPoint: Point = .zero, transformer: Point.LocationTransformer? = nil) {
         let startLocation = range.location
         let newEndLocation = range.max + delta
 
@@ -15,12 +15,8 @@ extension InputEdit {
             return nil
         }
 
-        guard
-            let startPoint = transformer(startLocation),
-            let newEndPoint = transformer(newEndLocation)
-        else {
-            return nil
-        }
+        let startPoint = transformer?(startLocation) ?? .zero
+        let newEndPoint = transformer?(newEndLocation) ?? .zero
 
         self.init(startByte: UInt32(range.location * 2),
                   oldEndByte: UInt32(range.max * 2),

--- a/Sources/TreeSitterClient/TreeSitterClient.swift
+++ b/Sources/TreeSitterClient/TreeSitterClient.swift
@@ -83,10 +83,6 @@ public final class TreeSitterClient {
         self.synchronousLengthThreshold = synchronousLengthThreshold
     }
 
-    public var tree: Tree? {
-        parseState.tree
-    }
-
     private var hasQueuedWork: Bool {
         return outstandingEdits.count > 0
     }

--- a/Sources/TreeSitterClient/TreeSitterClient.swift
+++ b/Sources/TreeSitterClient/TreeSitterClient.swift
@@ -83,6 +83,10 @@ public final class TreeSitterClient {
         self.synchronousLengthThreshold = synchronousLengthThreshold
     }
 
+    public var tree: Tree? {
+        parseState.tree
+    }
+
     private var hasQueuedWork: Bool {
         return outstandingEdits.count > 0
     }

--- a/Sources/TreeSitterClient/TreeSitterClient.swift
+++ b/Sources/TreeSitterClient/TreeSitterClient.swift
@@ -54,7 +54,7 @@ public final class TreeSitterClient {
     // and tree-diffing will start to become noticibly laggy
     private let synchronousContentLengthThreshold: Int = 1_000_000
 
-    public let locationTransformer: Point.LocationTransformer
+    public let locationTransformer: Point.LocationTransformer?
     public var computeInvalidations: Bool
 
     /// Invoked when parts of the text content have changed
@@ -67,7 +67,7 @@ public final class TreeSitterClient {
     /// was true at the time an edit was applied.
     public var invalidationHandler: (IndexSet) -> Void
 
-    public init(language: Language, transformer: @escaping Point.LocationTransformer, synchronousLengthThreshold: Int = 1024) throws {
+    public init(language: Language, transformer: Point.LocationTransformer? = nil, synchronousLengthThreshold: Int = 1024) throws {
         self.parser = Parser()
         self.parseState = TreeSitterParseState(tree: nil)
         self.outstandingEdits = []
@@ -100,7 +100,7 @@ extension TreeSitterClient {
     ///
     /// - Parameter range: the range of content that will be affected by an edit
     public func willChangeContent(in range: NSRange) {
-        oldEndPoint = locationTransformer(range.max)
+        oldEndPoint = locationTransformer?(range.max)
     }
 
     /// Process a change in the underlying text content.
@@ -121,11 +121,7 @@ extension TreeSitterClient {
                                  limit: Int,
                                  readHandler: @escaping Parser.ReadBlock,
                                  completionHandler: @escaping () -> Void) {
-        guard let oldEndPoint = oldEndPoint else {
-            assertionFailure("oldEndPoint unavailable")
-            return
-        }
-
+        let oldEndPoint = oldEndPoint ?? .zero
         self.oldEndPoint = nil
 
         guard let inputEdit = InputEdit(range: range, delta: delta, oldEndPoint: oldEndPoint, transformer: locationTransformer) else {

--- a/Sources/TreeSitterClient/TreeSitterClient.swift
+++ b/Sources/TreeSitterClient/TreeSitterClient.swift
@@ -117,7 +117,11 @@ extension TreeSitterClient {
                                  limit: Int,
                                  readHandler: @escaping Parser.ReadBlock,
                                  completionHandler: @escaping () -> Void) {
-        let oldEndPoint = oldEndPoint ?? .zero
+        if locationTransformer != nil && oldEndPoint == nil {
+            assertionFailure("oldEndPoint unavailable")
+            return
+        }
+        let oldEndPoint = self.oldEndPoint ?? .zero
         self.oldEndPoint = nil
 
         guard let inputEdit = InputEdit(range: range, delta: delta, oldEndPoint: oldEndPoint, transformer: locationTransformer) else {


### PR DESCRIPTION
Inclusions

- TreeSitterClient can be initialized only with a language parameter. [Non-breaking change]

```swift
treeSitterClient = try! TreeSitterClient(language: language)
```

----

- `locationTransformer` function will be an optional function.[ Breaking change]

```swift
public let locationTransformer: Point.LocationTransformer?
```

