### PR TITLE
Prevent conversion of TextKit2 NSTextViews to TextKit1

### DIFF
--- a/Sources/Neon/NSTextView+VisibleRange.swift
+++ b/Sources/Neon/NSTextView+VisibleRange.swift
@@ -5,6 +5,17 @@ extension NSTextView {
 	func textRange(for rect: CGRect) -> NSRange {
 		let length = self.textStorage?.length ?? 0
 
+		// If we have a textLayoutManager, the view is using TextKit2
+		// and we shouldn't be responsible for converting it to TextKit1.
+		// In the future it might be useful to implement a version of
+		// this method that works correctly with the TextKit2 API to
+		// generate an accurate range for the given rect.
+		if #available(macOS 12.0, *) {
+			if self.textLayoutManager != nil {
+				return NSRange(0..<length)
+			}
+		}
+
 		guard let layoutManager = self.layoutManager else {
 			return NSRange(0..<length)
 		}

--- a/Tests/NeonTests/TextViewSystemInterfaceTests.swift
+++ b/Tests/NeonTests/TextViewSystemInterfaceTests.swift
@@ -100,5 +100,15 @@ final class TextViewSystemInterfaceTests: XCTestCase {
 	}
 #endif
 
+#if os(macOS)
+	@available(macOS 12.0, *)
+	func testVisibleTextRangePreservesTextKit2() throws {
+		let textView = TextView()
+		XCTAssertNotNil(textView.textLayoutManager)
+		let _ = textView.visibleTextRange
+		XCTAssertNotNil(textView.textLayoutManager)
+	}
+#endif
+
 }
 


### PR DESCRIPTION
Prevent conversion of TextKit2 NSTextViews to TextKit1 when requesting the visibleTextRange. For now if TextKit2 is detected on a text view, just return the whole range.