### PR TITLE
Store attributes in TextKit 1 text storage

### DIFF
--- a/Projects/NeonExample/ViewController.swift
+++ b/Projects/NeonExample/ViewController.swift
@@ -13,10 +13,15 @@ final class ViewController: NSViewController {
 
 		scrollView.documentView = textView
 		
+		let regularFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
+		let boldFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
+		let italicFont = NSFont(descriptor: regularFont.fontDescriptor.withSymbolicTraits(.italic), size: 16) ?? regularFont
 		let provider: TextViewSystemInterface.AttributeProvider = { token in
-			guard token.name.hasPrefix("keyword") else { return [:] }
-
-			return [NSAttributedString.Key.foregroundColor: NSColor.red]
+			return switch token.name {
+			case let keyword where keyword.hasPrefix("keyword"): [.foregroundColor: NSColor.red, .font: boldFont]
+			case "comment": [.foregroundColor: NSColor.green, .font: italicFont]
+			default: [.foregroundColor: NSColor.textColor, .font: regularFont]
+			}
 		}
 
 		let language = Language(language: tree_sitter_swift())
@@ -52,6 +57,10 @@ final class ViewController: NSViewController {
 	}
 
 	override func viewWillAppear() {
-		textView.string = "let value = \"hello world\"\nprint(value)"
+		textView.string = """
+		// Example Code!
+		let value = "hello world"
+		print(value)
+		"""
 	}
 }

--- a/Projects/NeonExample/ViewController.swift
+++ b/Projects/NeonExample/ViewController.swift
@@ -14,7 +14,7 @@ final class ViewController: NSViewController {
 		scrollView.documentView = textView
 		
 		let regularFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
-		let boldFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
+		let boldFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .bold)
 		let italicFont = NSFont(descriptor: regularFont.fontDescriptor.withSymbolicTraits(.italic), size: 16) ?? regularFont
 
 		// Alternatively, set `textView.typingAttributes = [.font: regularFont, ...]`

--- a/Projects/NeonExample/ViewController.swift
+++ b/Projects/NeonExample/ViewController.swift
@@ -16,6 +16,11 @@ final class ViewController: NSViewController {
 		let regularFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
 		let boldFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
 		let italicFont = NSFont(descriptor: regularFont.fontDescriptor.withSymbolicTraits(.italic), size: 16) ?? regularFont
+
+		// Alternatively, set `textView.typingAttributes = [.font: regularFont, ...]`
+		// if you want to customize other default (fallback) attributes.
+		textView.font = regularFont
+
 		let provider: TextViewSystemInterface.AttributeProvider = { token in
 			return switch token.name {
 			case let keyword where keyword.hasPrefix("keyword"): [.foregroundColor: NSColor.red, .font: boldFont]

--- a/Sources/Neon/TextViewHighlighter.swift
+++ b/Sources/Neon/TextViewHighlighter.swift
@@ -80,10 +80,21 @@ public final class TextViewHighlighter: NSObject {
 		treeSitterClient.invalidationHandler = { [weak self] in self?.handleInvalidation($0) }
 	}
 
-	public convenience init(textView: TextView, language: Language, highlightQuery: Query, attributeProvider: @escaping TextViewSystemInterface.AttributeProvider) throws {
+	public convenience init(
+		textView: TextView,
+		language: Language,
+		highlightQuery: Query,
+		executionMode: TreeSitterClient.ExecutionMode = .asynchronous(prefetch: true),
+		attributeProvider: @escaping TextViewSystemInterface.AttributeProvider
+	) throws {
 		let client = try TreeSitterClient(language: language, transformer: { _ in return .zero })
 
-		try self.init(textView: textView, client: client, highlightQuery: highlightQuery, attributeProvider: attributeProvider)
+		try self.init(
+			textView: textView,
+			client: client,
+			highlightQuery: highlightQuery,
+			executionMode: executionMode,
+			attributeProvider: attributeProvider)
 	}
 
 	@objc private func visibleContentChanged(_ notification: NSNotification) {

--- a/Sources/Neon/TextViewSystemInterface.swift
+++ b/Sources/Neon/TextViewSystemInterface.swift
@@ -61,15 +61,10 @@ extension TextViewSystemInterface: TextSystemInterface {
 			return
 		}
 
-		// next, textkit 1
-		#if os(macOS)
-		if let layoutManager = layoutManager {
-			layoutManager.setTemporaryAttributes(attrs, forCharacterRange: clampedRange)
-			return
-		}
-		#endif
-
-		// finally, fall back to applying color directly to the storage
+		// For TextKit 1: Fall back to applying styles directly to the storage.
+		// `NSLayoutManager.setTemporaryAttributes` is limited to attributes
+		// that don't affect layout, like color. So it ignores fonts,
+		// making font weight changes or italicizing text impossible.
 		assert(textStorage != nil, "TextView's NSTextStorage cannot be nil")
 		textStorage?.setAttributes(attrs, range: clampedRange)
 	}

--- a/Tests/NeonTests/TextViewSystemInterfaceTests.swift
+++ b/Tests/NeonTests/TextViewSystemInterfaceTests.swift
@@ -54,13 +54,13 @@ final class TextViewSystemInterfaceTests: XCTestCase {
 		var effectiveRange: NSRange = .zero
 
 		#if os(macOS)
-		let attrs = textView.layoutManager?.temporaryAttributes(atCharacterIndex: 0, effectiveRange: &effectiveRange) ?? [:]
+		let allAttrs = textView.textStorage?.attributes(at: 0, effectiveRange: &effectiveRange) ?? [:]
 		#else
 		let allAttrs = textView.textStorage.attributes(at: 0, effectiveRange: &effectiveRange)
+		#endif
 
 		// we have to remove some attributes, like font, that are normal for the textStorage.
 		let attrs = allAttrs.filter({ $0.key == .foregroundColor })
-		#endif
 
 		XCTAssertEqual(attrs.count, 1)
 		XCTAssertEqual(attrs[.foregroundColor] as? PlatformColor, PlatformColor.red)


### PR DESCRIPTION
`NSLayoutManager`'s temp attributes can't be fonts. So no font weight or italic text for anyone. Instead, store the attributes in the text storage directly. 

Since #26 that doesn't cause any extra work:

1. User types
2. Text storage updates and notifies the delegate about character (typed text) + attribute changes (text view typingAttributes)
3. Highlighting is performed
4. Attributes are applied
5. Text storage updates and notifies the delegate about attribute changes
6. Delegate ignores this 👍

| Before (TK1 and TK2) | After (TK1) |
| -- | -- | 
| <img width="300" alt="2023-11-18 12-11-14 NeonExample - Untitled@2x" src="https://github.com/ChimeHQ/Neon/assets/59080/3a3ebbcf-2614-42cb-9edd-b95212e0d93c"> | <img width="300" alt="2023-11-18 12-24-35 NeonExample - Untitled@2x" src="https://github.com/ChimeHQ/Neon/assets/59080/c7145936-2010-4228-bbd5-9af1ef086d9d"> |

This applies to TextKit 1 only.

TextKit 2 still looks like 'before'. (Out of scope with the knowledge I have)

Also the weird 'value' font appears to be a "hole" in the grammar. Nothing's applied there. I'm investigating. Works fine with the JS grammar I'm using because everything's something in JavaScript (:

