### PR TITLE
Fix build for non-macOS platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
 	name: "Neon",
-	platforms: [.macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4)],
+	platforms: [.macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v5)],
 	products: [
 		.library(name: "Neon", targets: ["Neon"]),
 	],

--- a/Sources/Neon/RangeStateValidator.swift
+++ b/Sources/Neon/RangeStateValidator.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Rearrange
 
-@available(macOS 10.15, iOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public final class RangeStateValidator {
 	public enum ValidationResult: Sendable, Hashable {
 		case success(NSRange)
@@ -94,7 +94,7 @@ public final class RangeStateValidator {
 	}
 }
 
-@available(macOS 10.15, iOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension RangeStateValidator {
 	private var length: Int {
 		configuration.lengthProvider()
@@ -123,7 +123,7 @@ extension RangeStateValidator {
 	}
 }
 
-@available(macOS 10.15, iOS 13.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension RangeStateValidator {
 	/// Computes the next contiguous invalid range
 	private func nextNeededRange() -> NSRange? {

--- a/Sources/Neon/RangeStateValidator.swift
+++ b/Sources/Neon/RangeStateValidator.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Rearrange
 
-@available(macOS 10.15, *)
+@available(macOS 10.15, iOS 13.0, *)
 public final class RangeStateValidator {
 	public enum ValidationResult: Sendable, Hashable {
 		case success(NSRange)
@@ -94,7 +94,7 @@ public final class RangeStateValidator {
 	}
 }
 
-@available(macOS 10.15, *)
+@available(macOS 10.15, iOS 13.0, *)
 extension RangeStateValidator {
 	private var length: Int {
 		configuration.lengthProvider()
@@ -123,7 +123,7 @@ extension RangeStateValidator {
 	}
 }
 
-@available(macOS 10.15, *)
+@available(macOS 10.15, iOS 13.0, *)
 extension RangeStateValidator {
 	/// Computes the next contiguous invalid range
 	private func nextNeededRange() -> NSRange? {


### PR DESCRIPTION
- `Task` usage requires iOS 133, tvOS 13, watchOS 6
- watchOS 4 was too old for SwiftTreeSitter build

I would love to propose an idea to catch `Package.swift` platform target inconsistencies but I have no solution :)