### PR TITLE
Use local neon in sample project

### DIFF
--- a/Projects/NeonExample.xcodeproj/project.pbxproj
+++ b/Projects/NeonExample.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 
 /* Begin PBXFileReference section */
 		5077D7FF2B08D1F1000A15B8 /* Neon */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Neon; path = ..; sourceTree = "<group>"; };
+		5077D8012B08DF5D000A15B8 /* NeonExample.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = NeonExample.xctestplan; sourceTree = "<group>"; };
 		C9610B3228C6AD4F008ADDE6 /* NeonExample-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NeonExample-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9610B3428C6AD4F008ADDE6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C9610B3628C6AD4F008ADDE6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -87,6 +88,7 @@
 		C9A60F7928C68FD9006883EC = {
 			isa = PBXGroup;
 			children = (
+				5077D8012B08DF5D000A15B8 /* NeonExample.xctestplan */,
 				5077D7FF2B08D1F1000A15B8 /* Neon */,
 				C9A60F8428C68FD9006883EC /* NeonExample */,
 				C9610B3328C6AD4F008ADDE6 /* NeonExample-iOS */,

--- a/Projects/NeonExample.xcodeproj/project.pbxproj
+++ b/Projects/NeonExample.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5077D7FF2B08D1F1000A15B8 /* Neon */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Neon; path = ..; sourceTree = "<group>"; };
 		C9610B3228C6AD4F008ADDE6 /* NeonExample-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "NeonExample-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9610B3428C6AD4F008ADDE6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C9610B3628C6AD4F008ADDE6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -86,6 +87,7 @@
 		C9A60F7928C68FD9006883EC = {
 			isa = PBXGroup;
 			children = (
+				5077D7FF2B08D1F1000A15B8 /* Neon */,
 				C9A60F8428C68FD9006883EC /* NeonExample */,
 				C9610B3328C6AD4F008ADDE6 /* NeonExample-iOS */,
 				C9A60F8328C68FD9006883EC /* Products */,

--- a/Projects/NeonExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Projects/NeonExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "neon",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ChimeHQ/Neon.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "4bc0fe43c46e2c08cf522d5db86666086b6e641e"
-      }
-    },
-    {
       "identity" : "rearrange",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/Rearrange",

--- a/Projects/NeonExample.xcodeproj/xcshareddata/xcschemes/NeonExample-iOS.xcscheme
+++ b/Projects/NeonExample.xcodeproj/xcshareddata/xcschemes/NeonExample-iOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9610B3128C6AD4F008ADDE6"
+               BuildableName = "NeonExample-iOS.app"
+               BlueprintName = "NeonExample-iOS"
+               ReferencedContainer = "container:NeonExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:NeonExample.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C9610B3128C6AD4F008ADDE6"
+            BuildableName = "NeonExample-iOS.app"
+            BlueprintName = "NeonExample-iOS"
+            ReferencedContainer = "container:NeonExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C9610B3128C6AD4F008ADDE6"
+            BuildableName = "NeonExample-iOS.app"
+            BlueprintName = "NeonExample-iOS"
+            ReferencedContainer = "container:NeonExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Projects/NeonExample.xcodeproj/xcshareddata/xcschemes/NeonExample.xcscheme
+++ b/Projects/NeonExample.xcodeproj/xcshareddata/xcschemes/NeonExample.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9A60F8128C68FD9006883EC"
+               BuildableName = "NeonExample.app"
+               BlueprintName = "NeonExample"
+               ReferencedContainer = "container:NeonExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:NeonExample.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C9A60F8128C68FD9006883EC"
+            BuildableName = "NeonExample.app"
+            BlueprintName = "NeonExample"
+            ReferencedContainer = "container:NeonExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C9A60F8128C68FD9006883EC"
+            BuildableName = "NeonExample.app"
+            BlueprintName = "NeonExample"
+            ReferencedContainer = "container:NeonExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Projects/NeonExample.xctestplan
+++ b/Projects/NeonExample.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "D94B5F04-903A-4976-996C-0514F18D645C",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "NeonTests",
+        "name" : "NeonTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "TreeSitterClientTests",
+        "name" : "TreeSitterClientTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
This is a totally optional change, please discard if that doesn't fit how you work:

- Reference local Neon package in the sample to make it editable;
- this also enables using the package's tests in Xcode for ⌘U!
- Adding these to a test plan, and thus a scheme