### PR TITLE
Expand iOS sample app

### DIFF
--- a/Projects/NeonExample-iOS/ViewController.swift
+++ b/Projects/NeonExample-iOS/ViewController.swift
@@ -15,16 +15,22 @@ final class ViewController: UIViewController {
 					  .appendingPathComponent("queries/highlights.scm")
 		let query = try! language.query(contentsOf: url!)
 
-		let attrProvider: TextViewSystemInterface.AttributeProvider = { token in
-			guard token.name.hasPrefix("keyword") else { return [:] }
+		let regularFont = UIFont.monospacedSystemFont(ofSize: 16, weight: .regular)
+		let boldFont = UIFont.monospacedSystemFont(ofSize: 16, weight: .bold)
+		let italicFont = regularFont.fontDescriptor.withSymbolicTraits(.traitItalic).map { UIFont(descriptor: $0, size: 16) } ?? regularFont
 
-			return [.foregroundColor: UIColor.red]
+		let provider: TextViewSystemInterface.AttributeProvider = { token in
+			return switch token.name {
+			case let keyword where keyword.hasPrefix("keyword"): [.foregroundColor: UIColor.red, .font: boldFont]
+			case "comment": [.foregroundColor: UIColor.green, .font: italicFont]
+			default: [.foregroundColor: UIColor.darkText, .font: regularFont]
+			}
 		}
 
 		return try! TextViewHighlighter(textView: textView,
 										language: language,
 										highlightQuery: query,
-										attributeProvider: attrProvider)
+										attributeProvider: provider)
 	}()
 
 	override func viewDidLoad() {
@@ -33,7 +39,11 @@ final class ViewController: UIViewController {
 		_ = highlighter.textView
 		_ = textView.layoutManager
 
-		textView.text = "var something = String()"
+		textView.text = """
+		// Example Code!
+		let value = "hello world"
+		print(value)
+		"""
 
 		self.view.addSubview(textView)
 		textView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Uses more code and more attributes, like the macOS app since #28 
![Simulator Screenshot - iPhone 14 - 2023-11-18 at 14 25 11](https://github.com/ChimeHQ/Neon/assets/59080/9abc25ca-a423-46b2-9ba7-bb0744530311)


The convenience components on iOS show the same behavior w.r.t. to the 'value' string:

With the font customization, I now realize that the cause of the weird 'value' style is this: the `clearStyle` call _sets_ the attributes to `[:]`, not clears the temporary attributes.

I have a fix up my sleeve but would prefer to discuss this separately