### PR TITLE
Default attributes

### DIFF
--- a/Projects/NeonExample-iOS/ViewController.swift
+++ b/Projects/NeonExample-iOS/ViewController.swift
@@ -19,17 +19,25 @@ final class ViewController: UIViewController {
 		let boldFont = UIFont.monospacedSystemFont(ofSize: 16, weight: .bold)
 		let italicFont = regularFont.fontDescriptor.withSymbolicTraits(.traitItalic).map { UIFont(descriptor: $0, size: 16) } ?? regularFont
 
+		// Set the default styles. This is applied by stock `NSTextStorage`s during
+		// so-called "attribute fixing" when you type, and we emulate that as
+		// part of the highlighting process in `TextViewSystemInterface`.
+		textView.font = regularFont
+		textView.textColor = .darkGray
+
 		let provider: TextViewSystemInterface.AttributeProvider = { token in
 			return switch token.name {
 			case let keyword where keyword.hasPrefix("keyword"): [.foregroundColor: UIColor.red, .font: boldFont]
 			case "comment": [.foregroundColor: UIColor.green, .font: italicFont]
-			default: [.foregroundColor: UIColor.darkText, .font: regularFont]
+			// Note: Default is not actually applied to unstyled/untokenized text.
+			default: [.foregroundColor: UIColor.blue, .font: regularFont]
 			}
 		}
 
 		return try! TextViewHighlighter(textView: textView,
 										language: language,
 										highlightQuery: query,
+										executionMode: .synchronous,
 										attributeProvider: provider)
 	}()
 

--- a/Projects/NeonExample-iOS/ViewController.swift
+++ b/Projects/NeonExample-iOS/ViewController.swift
@@ -45,7 +45,6 @@ final class ViewController: UIViewController {
 		super.viewDidLoad()
 
 		_ = highlighter.textView
-		_ = textView.layoutManager
 
 		textView.text = """
 		// Example Code!

--- a/Projects/NeonExample/ViewController.swift
+++ b/Projects/NeonExample/ViewController.swift
@@ -17,15 +17,18 @@ final class ViewController: NSViewController {
 		let boldFont = NSFont.monospacedSystemFont(ofSize: 16, weight: .bold)
 		let italicFont = NSFont(descriptor: regularFont.fontDescriptor.withSymbolicTraits(.italic), size: 16) ?? regularFont
 
-		// Alternatively, set `textView.typingAttributes = [.font: regularFont, ...]`
-		// if you want to customize other default (fallback) attributes.
+		// Set the default styles. This is applied by stock `NSTextStorage`s during
+		// so-called "attribute fixing" when you type, and we emulate that as
+		// part of the highlighting process in `TextViewSystemInterface`.
 		textView.font = regularFont
+		textView.textColor = .darkGray
 
 		let provider: TextViewSystemInterface.AttributeProvider = { token in
 			return switch token.name {
 			case let keyword where keyword.hasPrefix("keyword"): [.foregroundColor: NSColor.red, .font: boldFont]
 			case "comment": [.foregroundColor: NSColor.green, .font: italicFont]
-			default: [.foregroundColor: NSColor.textColor, .font: regularFont]
+			// Note: Default is not actually applied to unstyled/untokenized text.
+			default: [.foregroundColor: NSColor.blue, .font: regularFont]
 			}
 		}
 

--- a/Projects/NeonExample/ViewController.swift
+++ b/Projects/NeonExample/ViewController.swift
@@ -10,6 +10,7 @@ final class ViewController: NSViewController {
 
 	init() {
 		self.textView = NSTextView()
+		textView.isRichText = false  // Discards any attributes when pasting.
 
 		scrollView.documentView = textView
 		

--- a/Sources/Neon/TextViewSystemInterface.swift
+++ b/Sources/Neon/TextViewSystemInterface.swift
@@ -61,21 +61,7 @@ extension TextViewSystemInterface: TextSystemInterface {
 	private func setAttributes(_ attrs: [NSAttributedString.Key : Any]?, in range: NSRange) {
 		let clampedRange = clamped(range: range)
 
-		// Try TextKit 2 first
-		if
-			#available(macOS 12, iOS 15.0, tvOS 15.0, *),
-			let textLayoutManager = textLayoutManager,
-			let contentManager = textLayoutManager.textContentManager,
-			let textRange = NSTextRange(clampedRange, provider: contentManager)
-		{
-			// TextKit 2 uses temporary rendering attributes. These can be
-			// overwritten to clear.
-			let attrs = attrs ?? [:]
-			textLayoutManager.setRenderingAttributes(attrs, for: textRange)
-			return
-		}
-
-		// For TextKit 1: Fall back to applying styles directly to the storage.
+		// Both `NSTextLayoutManager.setRenderingAttributes` and
 		// `NSLayoutManager.setTemporaryAttributes` is limited to attributes
 		// that don't affect layout, like color. So it ignores fonts,
 		// making font weight changes or italicizing text impossible.

--- a/Sources/Neon/TextViewSystemInterface.swift
+++ b/Sources/Neon/TextViewSystemInterface.swift
@@ -14,9 +14,20 @@ public struct TextViewSystemInterface {
 
 	public let textView: TextView
 	public let attributeProvider: AttributeProvider
+	public var defaultTextViewAttributes: [NSAttributedString.Key: Any] = [:]
 
-	public init(textView: TextView, attributeProvider: @escaping AttributeProvider) {
+	public init(
+		textView: TextView,
+		defaultTextViewAttributes: [NSAttributedString.Key: Any] = [:],
+		attributeProvider: @escaping AttributeProvider
+	) {
 		self.textView = textView
+		// Assume that the default styles used before enabling any highlighting
+		// should be retained, unless client code overrides this.
+		self.defaultTextViewAttributes = [
+			 .font: textView.font as Any,
+			 .foregroundColor: textView.textColor as Any,
+		].merging(defaultTextViewAttributes) { _, override in override }
 		self.attributeProvider = attributeProvider
 	}
 
@@ -39,13 +50,6 @@ public struct TextViewSystemInterface {
 
 	public var textStorage: NSTextStorage? {
 		return textView.textStorage
-	}
-
-	var defaultTextViewAttributes: [NSAttributedString.Key: Any] {
-		[
-			.font: textView.font as Any,
-			.foregroundColor: textView.textColor as Any,
-		]
 	}
 }
 

--- a/Tests/NeonTests/TextViewSystemInterfaceTests.swift
+++ b/Tests/NeonTests/TextViewSystemInterfaceTests.swift
@@ -65,7 +65,6 @@ final class TextViewSystemInterfaceTests: XCTestCase {
 		XCTAssertEqual(attrs.count, 1)
 		XCTAssertEqual(attrs[.foregroundColor] as? PlatformColor, PlatformColor.red)
 		XCTAssertEqual(effectiveRange, NSRange(0..<6))
-
 	}
 #endif
 
@@ -91,15 +90,13 @@ final class TextViewSystemInterfaceTests: XCTestCase {
 
 		system.applyStyle(to: Token(name: "test", range: NSRange(0..<6)))
 
-		let documentRange = textLayoutManager.documentRange
+		let textStorage = try XCTUnwrap(system.textStorage)
+		let documentRange = NSRange(location: 0, length: textStorage.length)
 
-		var attrRangePairs = [([NSAttributedString.Key: Any], NSTextRange)]()
-
-		textLayoutManager.enumerateRenderingAttributes(from: documentRange.location, reverse: false, using: { _, attrs, range in
+		var attrRangePairs = [([NSAttributedString.Key: Any], NSRange)]()
+		textStorage.enumerateAttributes(in: documentRange) { attrs, range, _ in
 			attrRangePairs.append((attrs, range))
-
-			return true
-		})
+		}
 
 		XCTAssertEqual(attrRangePairs.count, 1)
 


### PR DESCRIPTION
#33 brings up the issue that there's no auto fallback when using stored attributes.

Text view `font` and `textColor` aren't permanent, either, and cannot be used to compute the "reset to this" style. They'll default to whatever is near, more or less. (As you type in differently colored regions, you can observe how they change). 

See the difference of computed vs stored default attributes here -- the default font of the text view is supposed to be dark gray, but changing the first line's markup doesn't properly set the color or font:

### Computed
https://github.com/ChimeHQ/Neon/assets/59080/b93e8aa5-69d3-429f-bd51-e314fc6072cf 
### Stored
https://github.com/ChimeHQ/Neon/assets/59080/5f17738f-500e-48dd-bbd3-7e2f94e3829d

With stored attributes, stored _fallback_ attributes are required to get similar behavior to temporary layout attributes.
