### PR TITLE
Add correct visible range calculation for TextKit 2

### DIFF
--- a/Sources/Neon/NSTextView+VisibleRange.swift
+++ b/Sources/Neon/NSTextView+VisibleRange.swift
@@ -33,16 +33,16 @@ extension NSTextView {
 	}
 
 	public var visibleTextRange: NSRange {
-        guard
-            #available(macOS 12.0, *),
-            let textLayoutManager,
-            let viewportRange = textLayoutManager.textViewportLayoutController.viewportRange,
-            let textContentManager = textLayoutManager.textContentManager
-        else {
-            return textRange(for: visibleRect)
-        }
-        
-        return NSRange(viewportRange, provider: textContentManager)
+		guard
+			#available(macOS 12.0, *),
+			let textLayoutManager,
+			let viewportRange = textLayoutManager.textViewportLayoutController.viewportRange,
+			let textContentManager = textLayoutManager.textContentManager
+		else {
+			return textRange(for: visibleRect)
+		}
+
+		return NSRange(viewportRange, provider: textContentManager)
 	}
 }
 #endif

--- a/Sources/Neon/NSTextView+VisibleRange.swift
+++ b/Sources/Neon/NSTextView+VisibleRange.swift
@@ -33,7 +33,16 @@ extension NSTextView {
 	}
 
 	public var visibleTextRange: NSRange {
-		return textRange(for: visibleRect)
+        guard
+            #available(macOS 12.0, *),
+            let textLayoutManager,
+            let viewportRange = textLayoutManager.textViewportLayoutController.viewportRange,
+            let textContentManager = textLayoutManager.textContentManager
+        else {
+            return textRange(for: visibleRect)
+        }
+        
+        return NSRange(viewportRange, provider: textContentManager)
 	}
 }
 #endif


### PR DESCRIPTION
Previously, `visibleTextRange` would return the whole range when using TextKit 2. With this change, it will only return the actual visible text range.