### PR TITLE
Fixes a compiler error when swift 6's strict concurrency checking is enabled

### DIFF
--- a/Sources/Neon/TextSystemStyler.swift
+++ b/Sources/Neon/TextSystemStyler.swift
@@ -14,13 +14,14 @@ import RangeState
 public final class TextSystemStyler<Interface: TextSystemInterface> {
 	private let textSystem: Interface
 	private let tokenProvider: TokenProvider
+	private let tokenValidator: TokenSystemValidator<Interface>
 	private let validator: SinglePhaseRangeValidator<Interface.Content>
 
 	public init(textSystem: Interface, tokenProvider: TokenProvider) {
 		self.textSystem = textSystem
 		self.tokenProvider = tokenProvider
 
-		let tokenValidator = TokenSystemValidator(
+		self.tokenValidator = TokenSystemValidator(
 			textSystem: textSystem,
 			tokenProvider: tokenProvider
 		)
@@ -28,7 +29,7 @@ public final class TextSystemStyler<Interface: TextSystemInterface> {
 		self.validator = SinglePhaseRangeValidator(
 			configuration: .init(
 				versionedContent: textSystem.content,
-				provider: tokenValidator.validationProvider
+				provider: self.tokenValidator.validationProvider
 			)
 		)
 	}

--- a/Sources/Neon/TextSystemStyler.swift
+++ b/Sources/Neon/TextSystemStyler.swift
@@ -14,14 +14,13 @@ import RangeState
 public final class TextSystemStyler<Interface: TextSystemInterface> {
 	private let textSystem: Interface
 	private let tokenProvider: TokenProvider
-	private let tokenValidator: TokenSystemValidator<Interface>
 	private let validator: SinglePhaseRangeValidator<Interface.Content>
 
 	public init(textSystem: Interface, tokenProvider: TokenProvider) {
 		self.textSystem = textSystem
 		self.tokenProvider = tokenProvider
 
-		self.tokenValidator = TokenSystemValidator(
+		let tokenValidator = TokenSystemValidator(
 			textSystem: textSystem,
 			tokenProvider: tokenProvider
 		)
@@ -29,7 +28,7 @@ public final class TextSystemStyler<Interface: TextSystemInterface> {
 		self.validator = SinglePhaseRangeValidator(
 			configuration: .init(
 				versionedContent: textSystem.content,
-				provider: self.tokenValidator.validationProvider
+				provider: tokenValidator.validationProvider
 			)
 		)
 	}

--- a/Sources/Neon/TokenSystemValidator.swift
+++ b/Sources/Neon/TokenSystemValidator.swift
@@ -15,9 +15,15 @@ final class TokenSystemValidator<Interface: TextSystemInterface> {
 	}
 
 	var validationProvider: HybridSyncAsyncValueProvider<Validator.ContentRange, Validation, Never> {
-		.init(
-			syncValue: { self.validate($0) },
-			asyncValue: { _, range in await self.validate(range)}
+		HybridSyncAsyncValueProvider<Validator.ContentRange, Validation, Never>(
+			syncValue: { [weak self] range in
+				guard let self = self else { return nil }
+				return self.validate(range)
+			},
+			asyncValue: { [weak self] _, range in
+				guard let self = self else { return .stale }
+				return await self.validate(range)
+			}
 		)
 	}
 

--- a/Sources/Neon/TokenSystemValidator.swift
+++ b/Sources/Neon/TokenSystemValidator.swift
@@ -15,15 +15,9 @@ final class TokenSystemValidator<Interface: TextSystemInterface> {
 	}
 
 	var validationProvider: HybridSyncAsyncValueProvider<Validator.ContentRange, Validation, Never> {
-		HybridSyncAsyncValueProvider<Validator.ContentRange, Validation, Never>(
-			syncValue: { [weak self] range in
-				guard let self = self else { return nil }
-				return self.validate(range)
-			},
-			asyncValue: { [weak self] _, range in
-				guard let self = self else { return .stale }
-				return await self.validate(range)
-			}
+		.init(
+			syncValue: { self.validate($0) },
+			asyncValue: { [self] _, range in await self.validate(range) }
 		)
 	}
 


### PR DESCRIPTION
The concurrency checking doesn't like the validationProvider in TokenSystemValidator. After fixing the concurrency complaint, it looks like the tokenValidator isn't being strongly held any more, so a new tokenValidator property was added to TextSystemStyler.